### PR TITLE
Add perceptualTolerance parameter to Diffing+bitmap to compare perceptual differences using Delta E 1994

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /build
 /.gradle
-.idea
-local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build
 /.gradle
+.idea
+local.properties

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -1,16 +1,13 @@
 package com.quickbird.snapshot
 
+import android.util.Log
 import androidx.annotation.ColorInt
 import kotlin.math.cbrt
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
 
-data class Color(@ColorInt val value: Int) {
-    fun equals(other: Color, any: Any) {
-
-    }
-}
+data class Color(@ColorInt val value: Int)
 
 val @receiver:ColorInt Int.color
     get() = Color(this)
@@ -71,9 +68,11 @@ private fun Color.difference(other: Color): Double {
     val sc = 1.0 + 0.045 * cBar
     val sh = 1.0 + 0.015 * cBar
 
-    return sqrt(
+    val deltaE = sqrt(
         (deltaL / sl).pow(2) +
                 (deltaC / (kc * sc)).pow(2) +
                 (deltaH / (kh * sh)).pow(2)
     )
+    Log.d("SnapshotDiffing", "Delta E: $deltaE")
+    return deltaE
 }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -15,13 +15,13 @@ data class Color(@ColorInt val value: Int) {
 val @receiver:ColorInt Int.color
     get() = Color(this)
 
-fun Color.isSimilar(other: Color, perceptualTolerance: Double): Boolean {
+fun Color.deltaE(other: Color): Double {
     if (this == other) {
-        return true
+        return 0.0
     }
     // Compute the Delta E 2000 difference between the two colors in the CIELAB color space and return whether it's within the perceptual tolerance
     //
-    return min(this.difference(other) / 100, 1.0) <= perceptualTolerance
+    return min(this.difference(other) / 100, 1.0)
 }
 
 // Convert the color to the CIELAB color space

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -40,30 +40,16 @@ private fun Color.toXYZ(): DoubleArray {
 
     // Inverse sRGB companding
     //
-    r = if (r <= 0.04045) {
-        r / 12.92
-    } else {
-        ((r + 0.055) / 1.055).pow(2.4)
-    }
-
-    g = if (g > 0.04045) {
-        ((g + 0.055) / 1.055).pow(2.4)
-    } else {
-        g / 12.92
-    }
-
-    b = if (b > 0.04045) {
-        ((b + 0.055) / 1.055).pow(2.4)
-    } else {
-        b / 12.92
-    }
+    r = if (r <= 0.04045) r / 12.92 else ((r + 0.055) / 1.055).pow(2.4)
+    g = if (g <= 0.04045) g / 12.92 else ((g + 0.055) / 1.055).pow(2.4)
+    b = if (b <= 0.04045) b / 12.92 else ((b + 0.055) / 1.055).pow(2.4)
 
     // Linear RGB to XYZ using sRGB color space and D65 white reference white
     //
     return doubleArrayOf(
-        (0.4124564 * r + 0.3575761 * g + 0.1804375 * b),
-        (0.2126729 * r + 0.7151522 * g + 0.0721750 * b),
-        (0.0193339 * r + 0.1191920 * g + 0.9503041 * b)
+        0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
+        0.2126729 * r + 0.7151522 * g + 0.0721750 * b,
+        0.0193339 * r + 0.1191920 * g + 0.9503041 * b
     )
 }
 
@@ -79,30 +65,16 @@ private fun Color.toLAB(): DoubleArray {
     val Yr = 1.000
     val Zr = 1.0888
 
-    var xr = x / Xr
-    var yr = y / Yr
-    var zr = z / Zr
+    val xr = x / Xr
+    val yr = y / Yr
+    val zr = z / Zr
 
     val e = 0.008856
     val k = 903.3
 
-    val fx = if ( xr > e ) {
-        cbrt(xr)
-    } else {
-        ((k * xr) + 16) / 116.0
-    }
-
-    val fy = if ( yr > e ) {
-        cbrt(yr)
-    } else {
-        ((k * yr) + 16) / 116.0
-    }
-
-    val fz = if ( zr > e ) {
-        cbrt(zr)
-    } else {
-        ((k * zr) + 16) / 116.0
-    }
+    val fx = if (xr > e) cbrt(xr) else ((k * xr) + 16) / 116.0
+    val fy = if (yr > e) cbrt(yr) else ((k * yr) + 16) / 116.0
+    val fz = if (zr > e) cbrt(zr) else ((k * zr) + 16) / 116.0
 
     return doubleArrayOf(
         116 * fy - 16,
@@ -120,11 +92,9 @@ private fun Color.deltaE1994(other: Color): Double {
     val (l2, a2, b2) = other.toLAB()
 
     val deltaL = l1 - l2
-
     val c1 = sqrt(a1.pow(2) + b1.pow(2))
     val c2 = sqrt(a2.pow(2) + b2.pow(2))
     val deltaC = c1 - c2
-
     val deltaA = a1 - a2
     val deltaB = b1 - b2
     val deltaH = sqrt(abs(deltaA.pow(2) + deltaB.pow(2) - deltaC.pow(2)))

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -1,8 +1,79 @@
 package com.quickbird.snapshot
 
 import androidx.annotation.ColorInt
+import kotlin.math.cbrt
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sqrt
 
-data class Color(@ColorInt val value: Int)
+data class Color(@ColorInt val value: Int) {
+    fun equals(other: Color, any: Any) {
+
+    }
+}
 
 val @receiver:ColorInt Int.color
     get() = Color(this)
+
+fun Color.isSimilar(other: Color, perceptualTolerance: Double): Boolean {
+    if (this == other) {
+        return true
+    }
+    // Compute the Delta E 2000 difference between the two colors in the CIELAB color space and return whether it's within the perceptual tolerance
+    //
+    return min(this.difference(other) / 100, 1.0) <= perceptualTolerance
+}
+
+// Convert the color to the CIELAB color space
+//
+private fun Color.toLAB(): DoubleArray {
+    val r = (value shr 16 and 0xff) / 255.0
+    val g = (value shr 8 and 0xff) / 255.0
+    val b = (value and 0xff) / 255.0
+
+    val x = r * 0.4124564 + g * 0.3575761 + b * 0.1804375
+    val y = r * 0.2126729 + g * 0.7151522 + b * 0.0721750
+    val z = r * 0.0193339 + g * 0.1191920 + b * 0.9503041
+
+    val l1 = 116 * f(y / 1.0) - 16
+    val a1 = 500 * (f(x / 0.95047) - f(y / 1.0))
+    val b1 = 200 * (f(y / 1.0) - f(z / 1.08883))
+
+    return doubleArrayOf(l1, a1, b1)
+}
+
+private fun f(t: Double): Double {
+    return if (t > 0.008856) cbrt(t) else (7.787 * t) + (16 / 116.0)
+}
+
+// Calculates CIEDE2000 (Delta E 2000) between two colors in the CIELAB color space returning a value between 0-100 (0 means no difference, 100 means completely opposite)
+//
+// This is the most recent and accurate formula, which includes corrections for perceptual uniformity
+// Platform difference: iOS uses CIE94 (Delta E 1994) for color difference calculations
+//
+private fun Color.difference(other: Color): Double {
+    val lab1 = this.toLAB()
+    val lab2 = other.toLAB()
+
+    val deltaL = lab1[0] - lab2[0]
+    val lBar = (lab1[0] + lab2[0]) / 2.0
+    val c1 = sqrt(lab1[1].pow(2) + lab1[2].pow(2))
+    val c2 = sqrt(lab2[1].pow(2) + lab2[2].pow(2))
+    val cBar = (c1 + c2) / 2.0
+    val deltaC = c1 - c2
+    val deltaA = lab1[1] - lab2[1]
+    val deltaB = lab1[2] - lab2[2]
+    val deltaH = sqrt(deltaA.pow(2) + deltaB.pow(2) - deltaC.pow(2))
+
+    val sl = 1.0
+    val kc = 1.0
+    val kh = 1.0
+    val sc = 1.0 + 0.045 * cBar
+    val sh = 1.0 + 0.015 * cBar
+
+    return sqrt(
+        (deltaL / sl).pow(2) +
+                (deltaC / (kc * sc)).pow(2) +
+                (deltaH / (kh * sh)).pow(2)
+    )
+}

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -33,30 +33,26 @@ private fun Color.toXYZ(): DoubleArray {
     var r = AndroidColor.red(this.value) / 255.0
     var g = AndroidColor.green(this.value) / 255.0
     var b = AndroidColor.blue(this.value) / 255.0
+    Log.d("SnapshotDiffing", "R: $r, G: $g, B: $b")
 
-    r = if (r > 0.04045) {
-        ((r + 0.055) / 1.055).pow(2.4)
+    r = if (r <= 0.04045) {
+        r / 12.92
     } else {
-        r / 12.92;
+        ((r + 0.055) / 1.055).pow(2.4)
     }
 
     g = if (g > 0.04045) {
         ((g + 0.055) / 1.055).pow(2.4)
     } else {
-        g / 12.92;
+        g / 12.92
     }
 
     b = if (b > 0.04045) {
         ((b + 0.055) / 1.055).pow(2.4)
     } else {
-        b / 12.92;
+        b / 12.92
     }
-
-    r *= 100
-    g *= 100
-    b *= 100
-    Log.d("SnapshotDiffing", "R: $r, G: $g, B: $b");
-
+    
     return doubleArrayOf(
         (0.4124 * r + 0.3576 * g + 0.1805 * b),
         (0.2126 * r + 0.7152 * g + 0.0722 * b),
@@ -85,13 +81,13 @@ private fun Color.toLAB(): DoubleArray {
     val k = 903.3
 
     val fx = if ( xr > e ) {
-        xr.pow(1/3)
+        xr.pow(1 / 3)
     } else {
         ((k * xr) + 16 / 116.0)
     }
 
     val fy = if ( yr > e ) {
-        yr.pow(1/3)
+        yr.pow(1 / 3)
     } else {
         ((k * yr) + 16 / 116.0)
     }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -36,7 +36,7 @@ private fun Color.toXYZ(): DoubleArray {
     var r = AndroidColor.red(this.value) / 255.0
     var g = AndroidColor.green(this.value) / 255.0
     var b = AndroidColor.blue(this.value) / 255.0
-    Log.d("SnapshotDiffing", "R: $r, G: $g, B: $b")
+    // Log.d("SnapshotDiffing", "R: $r, G: $g, B: $b")
 
     // Inverse sRGB Companding
     //
@@ -65,7 +65,7 @@ private fun Color.toXYZ(): DoubleArray {
         (0.2126729 * r + 0.7151522 * g + 0.0721750 * b),
         (0.0193339 * r + 0.1191920 * g + 0.9503041 * b)
     ).also {
-        Log.d("SnapshotDiffing", "X: ${it[0]}, Y: ${it[1]}, Z: ${it[2]}")
+        // Log.d("SnapshotDiffing", "X: ${it[0]}, Y: ${it[1]}, Z: ${it[2]}")
     }
 }
 
@@ -112,7 +112,7 @@ private fun Color.toLAB(): DoubleArray {
         500 * (fx - fy),
         200 * (fy - fz)
     ).also {
-        Log.d("SnapshotDiffing", "L: ${it[0]}, A: ${it[1]}, B: ${it[2]}")
+        // Log.d("SnapshotDiffing", "L: ${it[0]}, A: ${it[1]}, B: ${it[2]}")
     }
 }
 
@@ -148,6 +148,6 @@ private fun Color.difference(other: Color): Double {
                 (deltaC / (kc * sc)).pow(2) +
                 (deltaH / (kh * sh)).pow(2)
     ).also {
-        Log.d("SnapshotDiffing", "ΔE: $it")
+        // Log.d("SnapshotDiffing", "ΔE: $it")
     }
 }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -81,28 +81,31 @@ private fun Color.toLAB(): DoubleArray {
     var yr = y / Yr
     var zr = z / Zr
 
-    xr = if ( xr > 0.008856 ) {
+    val e = 0.008856
+    val k = 903.3
+
+    val fx = if ( xr > e ) {
         xr.pow(1/3)
     } else {
-        ((7.787 * xr) + 16 / 116.0)
+        ((k * xr) + 16 / 116.0)
     }
 
-    yr = if ( yr > 0.008856 ) {
+    val fy = if ( yr > e ) {
         yr.pow(1/3)
     } else {
-        ((7.787 * yr) + 16 / 116.0)
+        ((k * yr) + 16 / 116.0)
     }
 
-    zr = if ( zr > 0.008856 ) {
+    val fz = if ( zr > e ) {
         zr.pow(1 / 3)
     } else {
-        ((7.787 * zr) + 16 / 116.0)
+        ((k * zr) + 16 / 116.0)
     }
 
     return doubleArrayOf(
-        (116 * yr) - 16,
-        500 * (xr - yr),
-        200 * (yr - zr)
+        (116 * fy) - 16,
+        500 * (fx - fy),
+        200 * (fy - fz)
     ).also {
         Log.d("SnapshotDiffing", "L: ${it[0]}, A: ${it[1]}, B: ${it[2]}")
     }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.annotation.ColorInt
 import kotlin.collections.component1
 import kotlin.math.abs
+import kotlin.math.cbrt
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -89,25 +90,25 @@ private fun Color.toLAB(): DoubleArray {
     val k = 903.3
 
     val fx = if ( xr > e ) {
-        xr.pow(1 / 3)
+        cbrt(xr)
     } else {
-        ((k * xr) + 16 / 116.0)
+        ((k * xr) + 16) / 116.0
     }
 
     val fy = if ( yr > e ) {
-        yr.pow(1 / 3)
+        cbrt(yr)
     } else {
-        ((k * yr) + 16 / 116.0)
+        ((k * yr) + 16) / 116.0
     }
 
     val fz = if ( zr > e ) {
-        zr.pow(1 / 3)
+        cbrt(zr)
     } else {
-        ((k * zr) + 16 / 116.0)
+        ((k * zr) + 16) / 116.0
     }
 
     return doubleArrayOf(
-        (116 * fy) - 16,
+        116 * fy - 16,
         500 * (fx - fy),
         200 * (fy - fz)
     ).also {

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -5,6 +5,7 @@ import android.graphics.Color as AndroidColor
 import android.util.Log
 import androidx.annotation.ColorInt
 import kotlin.collections.component1
+import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
@@ -40,20 +41,20 @@ private fun Color.toXYZ(): DoubleArray {
     }
 
     g = if (g > 0.04045) {
-        ((g + 0.055) / 1.055).pow(2.4);
+        ((g + 0.055) / 1.055).pow(2.4)
     } else {
         g / 12.92;
     }
 
     b = if (b > 0.04045) {
-        ((b + 0.055) / 1.055).pow(2.4);
+        ((b + 0.055) / 1.055).pow(2.4)
     } else {
         b / 12.92;
     }
 
-    r *= 100;
-    g *= 100;
-    b *= 100;
+    r *= 100
+    g *= 100
+    b *= 100
     Log.d("SnapshotDiffing", "R: $r, G: $g, B: $b");
 
     return doubleArrayOf(
@@ -80,22 +81,23 @@ private fun Color.toLAB(): DoubleArray {
     var yr = y / Yr
     var zr = z / Zr
 
-    if ( xr > 0.008856 ) {
-        xr = xr.pow(1/3)
+    xr = if ( xr > 0.008856 ) {
+        xr.pow(1/3)
     } else {
-        xr = ((7.787 * xr) + 16 / 116.0)
+        ((7.787 * xr) + 16 / 116.0)
     }
 
-    if ( yr > 0.008856 ) {
-        yr = yr.pow(1/3)
+    yr = if ( yr > 0.008856 ) {
+        yr.pow(1/3)
     } else {
-        yr = ((7.787 * yr) + 16 / 116.0)
+        ((7.787 * yr) + 16 / 116.0)
     }
 
-    if ( zr > 0.008856 )
-        zr = zr.pow(1/3)
-    else
-    zr = ((7.787 * zr) + 16 / 116.0)
+    zr = if ( zr > 0.008856 ) {
+        zr.pow(1 / 3)
+    } else {
+        ((7.787 * zr) + 16 / 116.0)
+    }
 
     return doubleArrayOf(
         (116 * yr) - 16,
@@ -121,9 +123,7 @@ private fun Color.difference(other: Color): Double {
 
     val deltaA = a1 - a2
     val deltaB = b1 - b2
-    // TODO: The value for ΔH is not actually needed. Rather, ΔH^2 is needed instead. So an optimization might be to avoid the square root altogether.
-    //
-    val deltaH = sqrt(max(deltaA.pow(2) + deltaB.pow(2) - deltaC.pow(2), 0.0))
+    val deltaH = sqrt(abs(deltaA.pow(2) + deltaB.pow(2) - deltaC.pow(2)))
 
     val sl = 1
     val kl = 1

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -1,8 +1,6 @@
 package com.quickbird.snapshot
 
-import android.annotation.SuppressLint
 import android.graphics.Color as AndroidColor
-import android.util.Log
 import androidx.annotation.ColorInt
 import kotlin.collections.component1
 import kotlin.math.abs

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Color.kt
@@ -31,56 +31,22 @@ fun Color.deltaE(other: Color): Double {
  * Convert the color to the CIE XYZ color space within nominal range of [0.0, 1.0]
  * using sRGB color space and D65 white reference white
  */
-private fun Color.toXYZ(): DoubleArray {
-    // Values must be within nominal range of [0.0, 1.0]
-    //
-    var r = AndroidColor.red(this.value) / 255.0
-    var g = AndroidColor.green(this.value) / 255.0
-    var b = AndroidColor.blue(this.value) / 255.0
-
-    // Inverse sRGB companding
-    //
-    r = if (r <= 0.04045) r / 12.92 else ((r + 0.055) / 1.055).pow(2.4)
-    g = if (g <= 0.04045) g / 12.92 else ((g + 0.055) / 1.055).pow(2.4)
-    b = if (b <= 0.04045) b / 12.92 else ((b + 0.055) / 1.055).pow(2.4)
-
-    // Linear RGB to XYZ using sRGB color space and D65 white reference white
-    //
-    return doubleArrayOf(
-        0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
-        0.2126729 * r + 0.7151522 * g + 0.0721750 * b,
-        0.0193339 * r + 0.1191920 * g + 0.9503041 * b
-    )
-}
-
 /**
  * Convert the color to the CIE LAB color space using sRGB color space and D65 white reference white
  */
-private fun Color.toLAB(): DoubleArray {
-    val (x, y, z) = this.toXYZ()
-
-    // CIE standard illuminant D65
-    //
-    val Xr = 0.9504
-    val Yr = 1.000
-    val Zr = 1.0888
-
-    val xr = x / Xr
-    val yr = y / Yr
-    val zr = z / Zr
-
-    val e = 0.008856
-    val k = 903.3
-
-    val fx = if (xr > e) cbrt(xr) else ((k * xr) + 16) / 116.0
-    val fy = if (yr > e) cbrt(yr) else ((k * yr) + 16) / 116.0
-    val fz = if (zr > e) cbrt(zr) else ((k * zr) + 16) / 116.0
-
-    return doubleArrayOf(
-        116 * fy - 16,
-        500 * (fx - fy),
-        200 * (fy - fz)
+private fun Color.toLAB(): FloatArray {
+    val labConnector = ColorSpace.connect(
+        ColorSpace.get(ColorSpace.Named.SRGB),
+        ColorSpace.get(ColorSpace.Named.CIE_LAB)
     )
+
+    val rgb = floatArrayOf(
+        AndroidColor.red(value) / 255.0f,
+        AndroidColor.green(value) / 255.0f,
+        AndroidColor.blue(value) / 255.0f
+    )
+
+    return labConnector.transform(rgb[0], rgb[1], rgb[2])
 }
 
 /**

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -6,10 +6,11 @@ import android.graphics.Color as AndroidColor
 
 private var maximumDeltaE: Double? = null
 
+
 fun Diffing.Companion.bitmap(
     colorDiffing: Diffing<Color>,
-    tolerance: Double = 0.0,
-    perceptualTolerance: Double = 0.0
+    tolerance: Double = 0.0,  // 0.0 means exact match, 1.0 means completely different
+    perceptualTolerance: Double = 0.0  // 0.0 means exact match, 1.0 means completely different
 ) = Diffing<Bitmap> { first, second ->
     val difference = first.differenceTo(second, perceptualTolerance)
 
@@ -54,8 +55,8 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
 
     val deltaEPixels = thisPixels
         .zip(otherPixels, Color::deltaE)
-    val deltaEDifference = deltaEPixels.count { it < perceptualTolerance }
+    val pixelDifferenceCount = deltaEPixels.count { it > (perceptualTolerance * 100) }
     maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
 
-    return deltaEDifference.toDouble() / thisPixels.size
+    return pixelDifferenceCount.toDouble() / thisPixels.size
 }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -23,11 +23,11 @@ fun Diffing.Companion.bitmap(
     val difference = first.differenceTo(second, perceptualTolerance)
 
     if (difference <= tolerance) {
-        Log.d("SnapshotDiffing", "Actual image difference ${difference.toString()}, required image difference ${tolerance.toString()}")
+        Log.d("SnapshotDiffing", "Actual image difference ${difference.toBigDecimal().toPlainString()}, required image difference ${tolerance.toBigDecimal().toPlainString()}")
         null
     } else {
-        var log = "Actual image difference ${difference.toString()} is greater than max allowed ${tolerance.toString()}"
-        if (maximumDeltaE != null) log += ", Actual perceptual difference ${maximumDeltaE.toString()} is greater than max allowed ${perceptualTolerance.toString()}"
+        var log = "Actual image difference ${difference.toBigDecimal().toPlainString()} is greater than max allowed ${tolerance.toBigDecimal().toPlainString()}"
+        if (maximumDeltaE != null) log += ", Actual perceptual difference ${maximumDeltaE.toString()} is greater than max allowed ${perceptualTolerance.toBigDecimal().toPlainString()}"
         Log.e("SnapshotDiffing", log)
 
         first.copy(first.config!!, true).apply {
@@ -67,8 +67,7 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
     val pixelDifferenceCount = if (perceptualTolerance > 0.0) {
         val deltaEPixels = thisPixels
             .zip(otherPixels, Color::deltaE)
-        // Perceptual tolerance is given in range of 0.0 (same) - 1.0 (completely different) that
-        // needs to be scaled when comparing against Delta E values between 0 (same) - 100 (completely different)
+        // Find the maximum delta E value for logging purposes
         //
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
         deltaEPixels.count { it > (perceptualTolerance) }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -18,7 +18,7 @@ fun Diffing.Companion.bitmap(
     } else {
         var log = "Actual image precision $difference is greater than required $tolerance"
         if (maximumDeltaE != null) log += ", Actual perceptual precision $maximumDeltaE is greater than required $perceptualTolerance"
-        Log.e("Snapshot diffing", log)
+        Log.e("SnapshotDiffing", log)
 
         first.copy(first.config, true).apply {
             updatePixels { x, y, color ->

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -2,6 +2,7 @@ package com.quickbird.snapshot
 
 import android.graphics.Bitmap
 import android.util.Log
+import java.io.File
 import android.graphics.Color as AndroidColor
 
 private var maximumDeltaE: Double? = null
@@ -62,7 +63,9 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
         // Perceptual tolerance is given in range of 0.0 (same) - 1.0 (completely different) that
         // needs to be scaled when comparing against Delta E values between 0 (same) - 100 (completely different)
         //
-        Log.d("SnapshotDiffing", deltaEPixels.toString())
+        File("somefile.txt").printWriter().use { out ->
+            out.println(deltaEPixels.toString())
+        }
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
         deltaEPixels.count { it > (perceptualTolerance) }
     } else {

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -6,11 +6,19 @@ import android.graphics.Color as AndroidColor
 
 private var maximumDeltaE: Double? = null
 
-
+/**
+ * A Bitmap comparison diffing strategy for comparing images based on pixel equality.
+ *
+ * @param colorDiffing A function that compares two colors and returns a color representing the difference.
+ * @param tolerance Total percentage of pixels that must match between image. The default value of 0.0% means all pixels must match
+ * @param perceptualTolerance Percentage each pixel can be different from source pixel and still considered
+ * a match. The default value of 0.0% means pixels must match perfectly whereas the recommended value of 0.02% mimics the
+ * [precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the human eye.
+ */
 fun Diffing.Companion.bitmap(
     colorDiffing: Diffing<Color>,
     tolerance: Double = 0.0,  // 0.0 means exact match, 1.0 means completely different
-    perceptualTolerance: Double = 0.0  // 0.0 means exact match, 1.0 means completely different
+    perceptualTolerance: Double = 0.0  // 0.0 means exact match, 1.0 means allow pixels to be completely different
 ) = Diffing<Bitmap> { first, second ->
     val difference = first.differenceTo(second, perceptualTolerance)
 
@@ -62,12 +70,7 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
         // Perceptual tolerance is given in range of 0.0 (same) - 1.0 (completely different) that
         // needs to be scaled when comparing against Delta E values between 0 (same) - 100 (completely different)
         //
-        val minimumDeltaE = deltaEPixels.minOrNull() ?: 0.0
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
-        val average = deltaEPixels.average()
-        val count = deltaEPixels.count()
-        val size = deltaEPixels.size
-        Log.e("SnapshotDiffing", "Minimum Delta E: $minimumDeltaE, Maximum Delta E: $maximumDeltaE, Average Delta E: $average, Count: $count, Size: $size")
         deltaEPixels.count { it > (perceptualTolerance) }
     } else {
         thisPixels

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -15,10 +15,11 @@ fun Diffing.Companion.bitmap(
     val difference = first.differenceTo(second, perceptualTolerance)
 
     if (difference <= tolerance) {
+        Log.d("SnapshotDiffing", "Actual image difference ${difference.toString()}, required image difference ${tolerance.toString()}")
         null
     } else {
-        var log = "Actual image tolerance $difference is greater than required $tolerance"
-        if (maximumDeltaE != null) log += ", Actual perceptual tolerance $maximumDeltaE is greater than required $perceptualTolerance"
+        var log = "Actual image difference ${difference.toString()} is greater than max allowed ${tolerance.toString()}"
+        if (maximumDeltaE != null) log += ", Actual perceptual difference ${maximumDeltaE.toString()} is greater than max allowed ${perceptualTolerance.toString()}"
         Log.e("SnapshotDiffing", log)
 
         first.copy(first.config!!, true).apply {

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -16,11 +16,11 @@ fun Diffing.Companion.bitmap(
     if (difference <= tolerance) {
         null
     } else {
-        var log = "Actual image precision $difference is greater than required $tolerance"
-        if (maximumDeltaE != null) log += ", Actual perceptual precision $maximumDeltaE is greater than required $perceptualTolerance"
+        var log = "Actual image tolerance $difference is greater than required $tolerance"
+        if (maximumDeltaE != null) log += ", Actual perceptual tolerance $maximumDeltaE is greater than required $perceptualTolerance"
         Log.e("SnapshotDiffing", log)
 
-        first.copy(first.config, true).apply {
+        first.copy(first.config!!, true).apply {
             updatePixels { x, y, color ->
                 if (x < second.width && y < second.height)
                     colorDiffing(color, second.getPixel(x, y).color) ?: color

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -71,12 +71,7 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
             .zip(otherPixels, Color::deltaE)
         // Find the maximum delta E value for logging purposes
         //
-        val minimumDeltaE = deltaEPixels.minOrNull() ?: 0.0
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
-        val average = deltaEPixels.average()
-        val count = deltaEPixels.count()
-        val size = deltaEPixels.size
-        Log.e("SnapshotDiffing", "Minimum Delta E: $minimumDeltaE, Maximum Delta E: ${maximumDeltaE!!.toBigDecimal().toPlainString()}, Average Delta E: $average, Count: $count, Size: $size")
         deltaEPixels.count { it > (perceptualTolerance) }
     } else {
         thisPixels

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -17,8 +17,8 @@ private var maximumDeltaE: Double? = null
  */
 fun Diffing.Companion.bitmap(
     colorDiffing: Diffing<Color>,
-    tolerance: Double = 0.0,  // 0.0 means exact match, 1.0 means completely different
-    perceptualTolerance: Double = 0.0  // 0.0 means exact match, 1.0 means allow pixels to be completely different
+    tolerance: Double = 0.0,
+    perceptualTolerance: Double = 0.0
 ) = Diffing<Bitmap> { first, second ->
     val difference = first.differenceTo(second, perceptualTolerance)
 
@@ -71,7 +71,12 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
             .zip(otherPixels, Color::deltaE)
         // Find the maximum delta E value for logging purposes
         //
+        val minimumDeltaE = deltaEPixels.minOrNull() ?: 0.0
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
+        val average = deltaEPixels.average()
+        val count = deltaEPixels.count()
+        val size = deltaEPixels.size
+        Log.e("SnapshotDiffing", "Minimum Delta E: $minimumDeltaE, Maximum Delta E: ${maximumDeltaE!!.toBigDecimal().toPlainString()}, Average Delta E: $average, Count: $count, Size: $size")
         deltaEPixels.count { it > (perceptualTolerance) }
     } else {
         thisPixels

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -2,8 +2,6 @@ package com.quickbird.snapshot
 
 import android.graphics.Bitmap
 import android.util.Log
-import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import java.io.File
 import android.graphics.Color as AndroidColor
 
 private var maximumDeltaE: Double? = null
@@ -64,11 +62,12 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
         // Perceptual tolerance is given in range of 0.0 (same) - 1.0 (completely different) that
         // needs to be scaled when comparing against Delta E values between 0 (same) - 100 (completely different)
         //
-        File(getInstrumentation().targetContext.filesDir.canonicalPath +
-                File.separator + "assets/somefile.txt").printWriter().use { out ->
-            out.println(deltaEPixels.toString())
-        }
+        val minimumDeltaE = deltaEPixels.minOrNull() ?: 0.0
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
+        val average = deltaEPixels.average()
+        val count = deltaEPixels.count()
+        val size = deltaEPixels.size
+        Log.e("SnapshotDiffing", "Minimum Delta E: $minimumDeltaE, Maximum Delta E: $maximumDeltaE, Average Delta E: $average, Count: $count, Size: $size")
         deltaEPixels.count { it > (perceptualTolerance) }
     } else {
         thisPixels

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -2,6 +2,7 @@ package com.quickbird.snapshot
 
 import android.graphics.Bitmap
 import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import java.io.File
 import android.graphics.Color as AndroidColor
 
@@ -63,7 +64,8 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
         // Perceptual tolerance is given in range of 0.0 (same) - 1.0 (completely different) that
         // needs to be scaled when comparing against Delta E values between 0 (same) - 100 (completely different)
         //
-        File("somefile.txt").printWriter().use { out ->
+        File(getInstrumentation().targetContext.filesDir.canonicalPath +
+                File.separator + "assets/somefile.txt").printWriter().use { out ->
             out.println(deltaEPixels.toString())
         }
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -5,9 +5,10 @@ import android.graphics.Color as AndroidColor
 
 fun Diffing.Companion.bitmap(
     colorDiffing: Diffing<Color>,
-    tolerance: Double = 0.0
+    tolerance: Double = 0.0,
+    perceptualTolerance: Double = 0.0
 ) = Diffing<Bitmap> { first, second ->
-    val difference = first differenceTo second
+    val difference = first.differenceTo(second, perceptualTolerance)
 
     if (difference <= tolerance) null
     else first.copy(first.config, true).apply {
@@ -36,13 +37,13 @@ val Diffing.Companion.intMean
         else first / 2 + second / 2
     }
 
-private infix fun Bitmap.differenceTo(other: Bitmap): Double {
+private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Double {
     val thisPixels = this.pixels
     val otherPixels = other.pixels
     if (thisPixels.size != otherPixels.size) return 100.0
 
     val differentPixelCount = thisPixels
-        .zip(otherPixels, Color::equals)
+        .zip(otherPixels) { a, b -> a.isSimilar(b, perceptualTolerance) }
         .count { !it }
 
     return differentPixelCount.toDouble() / thisPixels.size

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -53,10 +53,21 @@ private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Dou
     val otherPixels = other.pixels
     if (thisPixels.size != otherPixels.size) return 100.0
 
-    val deltaEPixels = thisPixels
-        .zip(otherPixels, Color::deltaE)
-    val pixelDifferenceCount = deltaEPixels.count { it > (perceptualTolerance * 100) }
-    maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
+    // Perceptually compare if the tolerance is greater than 0.0
+    //
+    val pixelDifferenceCount = if (perceptualTolerance > 0.0) {
+        val deltaEPixels = thisPixels
+            .zip(otherPixels, Color::deltaE)
+        // Perceptual tolerance is given in range of 0.0 - 1.0, this needs to be scaled
+        // when comparing against Delta E values between 0 (same) - 100 (completely different)
+        //
+        maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
+        deltaEPixels.count { it > (perceptualTolerance * 100) }
+    } else {
+        thisPixels
+            .zip(otherPixels, Color::equals)
+            .count { !it }
+    }
 
     return pixelDifferenceCount.toDouble() / thisPixels.size
 }

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -52,18 +52,19 @@ val Diffing.Companion.intMean
 private fun Bitmap.differenceTo(other: Bitmap, perceptualTolerance: Double): Double {
     val thisPixels = this.pixels
     val otherPixels = other.pixels
-    if (thisPixels.size != otherPixels.size) return 100.0
+    if (thisPixels.size != otherPixels.size) return 1.0
 
     // Perceptually compare if the tolerance is greater than 0.0
     //
     val pixelDifferenceCount = if (perceptualTolerance > 0.0) {
         val deltaEPixels = thisPixels
             .zip(otherPixels, Color::deltaE)
-        // Perceptual tolerance is given in range of 0.0 - 1.0, this needs to be scaled
-        // when comparing against Delta E values between 0 (same) - 100 (completely different)
+        // Perceptual tolerance is given in range of 0.0 (same) - 1.0 (completely different) that
+        // needs to be scaled when comparing against Delta E values between 0 (same) - 100 (completely different)
         //
+        Log.d("SnapshotDiffing", deltaEPixels.toString())
         maximumDeltaE = deltaEPixels.maxOrNull() ?: 0.0
-        deltaEPixels.count { it > (perceptualTolerance * 100) }
+        deltaEPixels.count { it > (perceptualTolerance) }
     } else {
         thisPixels
             .zip(otherPixels, Color::equals)

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -30,7 +30,7 @@ fun Diffing.Companion.bitmap(
         maximumDeltaE?.let { log += ", Actual perceptual difference ${it.toBigDecimal().toPlainString()} is greater than max allowed ${perceptualTolerance.toBigDecimal().toPlainString()}" }
         Log.e("SnapshotDiffing", log)
 
-        first.config?.let {
+        first.config.let {
             first.copy(it, true).apply {
                 updatePixels { x, y, color ->
                     if (x < second.width && y < second.height)

--- a/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
+++ b/snapshot/src/androidMain/kotlin/com/quickbird/snapshot/Diffing+bitmap.kt
@@ -27,14 +27,16 @@ fun Diffing.Companion.bitmap(
         null
     } else {
         var log = "Actual image difference ${difference.toBigDecimal().toPlainString()} is greater than max allowed ${tolerance.toBigDecimal().toPlainString()}"
-        if (maximumDeltaE != null) log += ", Actual perceptual difference ${maximumDeltaE.toString()} is greater than max allowed ${perceptualTolerance.toBigDecimal().toPlainString()}"
+        maximumDeltaE?.let { log += ", Actual perceptual difference ${it.toBigDecimal().toPlainString()} is greater than max allowed ${perceptualTolerance.toBigDecimal().toPlainString()}" }
         Log.e("SnapshotDiffing", log)
 
-        first.copy(first.config!!, true).apply {
-            updatePixels { x, y, color ->
-                if (x < second.width && y < second.height)
-                    colorDiffing(color, second.getPixel(x, y).color) ?: color
-                else color
+        first.config?.let {
+            first.copy(it, true).apply {
+                updatePixels { x, y, color ->
+                    if (x < second.width && y < second.height)
+                        colorDiffing(color, second.getPixel(x, y).color) ?: color
+                    else color
+                }
             }
         }
     }


### PR DESCRIPTION
### Differences from swift-snapshot-testing
Similar to what was implemented in [swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing/pull/628), with some slight differences

To match the established pattern of `tolerance`, this PR adds an optional `perceptualTolerance` parameter that allows you to specify the percentage each pixel can be different from source pixel and still considered a match. This parameter complements the existing `tolerance` parameter that determines the percentage of pixels that must be considered matching in order to consider the whole image matching.

The default value of 0.0 means pixels must match perfectly (and performs existing equality check). Any other value greater than 0.0 and less than or equal to 1.0, will be used when comparing each pixel where 0.0 (0%) means no difference and 1.0 (100%) means completely opposite. A suggested value of 0.01-0.02 is similar to the [precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the human eye.

Perceptual tolerance value | Description
-- | --
0.0 | Must be exactly equal
≤ 0.01 | Allows differences not perceptible by human eyes
≤ 0.02 | Allows differences possibly perceptible through close observation
≤ 0.1 | Allows differences perceptible at a glance
≤ 0.5 | Allows differences when more similar than opposite
≤ 1.0 | Allows any differences

Unlike swift-snapshot-testing, which uses a [CILabDeltaE](https://cifilter.io/CILabDeltaE) CoreImage Filter, we must do a byte-by-byte comparison, calculating Delta E values as on-the-fly.

Formula resource: http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_Lab.html

Description of https://github.com/pointfreeco/swift-snapshot-testing/pull/628...
> ### Problem
> The existing image matching precision strategy is not good at differentiating between a significant difference in a relatively small portion of a snapshot, and imperceivable differences in a large portion of the snapshot. For example, these snapshots below show that a 99.5% precision value fails an imperceivable background color change while allowing noticeable changes (text and color) to pass:

Reference | Fails | Passes
-- | -- | --
 ![image](https://github.com/user-attachments/assets/603da552-bba3-4c8e-8373-072b7f090df0) |  ![image](https://github.com/user-attachments/assets/fe0caa0f-855c-4dcd-aee6-e36399c6a6e7) |  ![image](https://github.com/user-attachments/assets/3ee7d273-36f2-43a0-9ac5-8db7dc2c7904)
  | Imperceivable background color difference | Significant text and color changes
>
>### Solution
>
>This PR adds a new optional perceptualPrecision parameter to image snapshotting which determines how perceptually similar a pixel must be to consider it matching. This parameter complements the existing precision parameter that determines the percentage of pixels that must be considered matching in order to consider the whole image matching.
>
>This approach is similar to https://github.com/pointfreeco/swift-snapshot-testing/pull/571 and https://github.com/pointfreeco/swift-snapshot-testing/pull/580 but uses perceptual distance rather than Euclidean distance of sRGB values. This is significant because the sRGB color space is [not perceptually uniform](https://programmingdesignsystems.com/color/perceptually-uniform-color-spaces). Pairs of colors with the same Euclidean distance can have large perceptual differences. The left and right colors of each row have the same Euclidean distance:

![image](https://github.com/user-attachments/assets/888552dd-1519-418a-a9f8-06bd282c9095)